### PR TITLE
Support for Docker secrets (Docker Swarm)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN set -x \
 COPY monit.d/ /etc/monit.d/
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY rclone.sh /rclone.sh
-RUN chmod -R +x /docker-entrypoint.sh /rclone.sh
+COPY env_secrets.sh /env_secrets.sh
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD [""]

--- a/README.md
+++ b/README.md
@@ -289,6 +289,15 @@ This docker image uses rclone and is focused on separating configuration from th
 * The last part is the formal configuration attribute. For example, `TYPE`, `ACCESS_KEY_ID` or `SERVER_SIDE_ENCRYPTION` are standard config elements for s3 rclone. Normally be prefixed like this: `--type`
 * You need to make sure `{{NAME}}` is unique to avoid any collisions in your configs. For example, you cant have multiple `RCLONE_CONFIG_MYS3` statements. If you have multiple S3 locations do something like `RCLONE_CONFIG_MYS3-01`, `RCLONE_CONFIG_MYS3-02` and `RCLONE_CONFIG_MYS3-03`
 
+## Using Docker Secrets
+Environment variables can be formed to point at the content of Docker secrets
+files, so as to avoid giving away sensitive information. Any environment
+variable which value looks like the following `{{DOCKER-SECRET:<path>}}` (note
+the leading and ending curly braces and the leading `DOCKER-SECRET:` keyword)
+will be replaced by the content of the file at `<path>` if it exists. Relative
+paths are automatically resolved to `/run/secrets` (the default path for Docker
+secrets), but absolute paths can also be used.
+
 # Performance Tips
 These tips come from  http://moo.nac.uci.edu/~hjm/HOWTO-rclone-to-Gdrive.html
 

--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ This docker image uses rclone and is focused on separating configuration from th
 ## Using Docker Secrets
 Environment variables can be formed to point at the content of Docker secrets
 files, so as to avoid giving away sensitive information. Any environment
-variable which value looks like the following `{{DOCKER-SECRET:<path>}}` (note
-the leading and ending curly braces and the leading `DOCKER-SECRET:` keyword)
-will be replaced by the content of the file at `<path>` if it exists. Relative
-paths are automatically resolved to `/run/secrets` (the default path for Docker
-secrets), but absolute paths can also be used.
+variable which value looks like the following `DOCKER-SECRET::<path>` (note the
+leading `DOCKER-SECRET` keyword and the double colon `::`) will be replaced by
+the content of the file at `<path>` if it exists. Relative paths are
+automatically resolved to `/run/secrets` (the default path for Docker secrets),
+but absolute paths can also be used.
 
 # Performance Tips
 These tips come from  http://moo.nac.uci.edu/~hjm/HOWTO-rclone-to-Gdrive.html

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,10 @@
 set -o nounset
 set -o pipefail
 
+# Make sure we always have a healthcheck URL, but empty unless specified
+: ${RCLONE_CROND_HEALTHCHECK_URL:=""}
+
+
 function crond() {
 
 if [[ -n "$RCLONE_CROND_SOURCE_PATH" ]] || [[ -n "$RCLONE_CROND_DESTINATION_PATH" ]]; then

--- a/env_secrets.sh
+++ b/env_secrets.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# The biggest bulk of this code originates from
+# https://medium.com/@basi/docker-environment-variables-expanded-from-secrets-8fa70617b3bc
 : ${ENV_SECRETS_DEBUG:=""}
 : ${ENV_SECRETS_DIR:=/run/secrets}
 

--- a/env_secrets.sh
+++ b/env_secrets.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+: ${ENV_SECRETS_DEBUG:=""}
+: ${ENV_SECRETS_DIR:=/run/secrets}
+
+env_secret_debug() {
+    if [ ! -z "$ENV_SECRETS_DEBUG" ]; then
+        echo -e "\033[1m$@\033[0m"
+    fi
+}
+
+
+# usage: env_secret_expand VAR
+#    ie: env_secret_expand 'XYZ_DB_PASSWORD'
+# (will check for "$XYZ_DB_PASSWORD" variable value for a placeholder that defines the
+#  name of the docker secret to use instead of the original value. For example:
+# XYZ_DB_PASSWORD={{DOCKER-SECRET:my-db.secret}}
+env_secret_expand() {
+    var="$1"
+    eval val=\$$var
+    if secret_name=$(expr match "$val" "{{DOCKER-SECRET:\([^}]\+\)}}$"); then
+        relative=$(dirname "${secret_name}")
+        if [ "${relative}" = "." ]; then
+            secret="${ENV_SECRETS_DIR}/${secret_name}"
+        else
+            secret=${secret_name}
+        fi
+        env_secret_debug "Secret file for $var: $secret"
+        if [ -f "$secret" ]; then
+            val=$(cat "${secret}")
+            export "$var"="$val"
+            env_secret_debug "Expanded variable: $var=$val"
+        else
+            env_secret_debug "Secret file does not exist! $secret"
+        fi
+    fi
+}
+
+
+env_secrets_expand() {
+    for env_var in $(printenv | cut -f1 -d"=")
+    do
+        env_secret_expand $env_var
+    done
+
+    if [ ! -z "$ENV_SECRETS_DEBUG" ]; then
+        echo -e "\n\033[1mExpanded environment variables\033[0m"
+        printenv
+    fi
+}
+
+env_secrets_expand

--- a/env_secrets.sh
+++ b/env_secrets.sh
@@ -19,11 +19,11 @@ env_secret_expand() {
     var="$1"
     eval val=\$$var
     if secret_name=$(expr match "$val" "{{DOCKER-SECRET:\([^}]\+\)}}$"); then
-        relative=$(dirname "${secret_name}")
-        if [ "${relative}" = "." ]; then
-            secret="${ENV_SECRETS_DIR}/${secret_name}"
-        else
+        absolute=$(expr substr "${secret_name}" 1 1)
+        if [ "${absolute}" = "/" ]; then
             secret=${secret_name}
+        else
+            secret="${ENV_SECRETS_DIR}/${secret_name}"
         fi
         env_secret_debug "Secret file for $var: $secret"
         if [ -f "$secret" ]; then

--- a/env_secrets.sh
+++ b/env_secrets.sh
@@ -20,7 +20,7 @@ env_secret_debug() {
 env_secret_expand() {
     var="$1"
     eval val=\$$var
-    if secret_name=$(expr match "$val" "{{DOCKER-SECRET:\([^}]\+\)}}$"); then
+    if secret_name=$(expr match "$val" "DOCKER-SECRET::\(.*\)$"); then
         absolute=$(expr substr "${secret_name}" 1 1)
         if [ "${absolute}" = "/" ]; then
             secret=${secret_name}

--- a/rclone.sh
+++ b/rclone.sh
@@ -2,6 +2,9 @@
 
 # Get the env variables so crond has them
 source /cron/rclone.env
+# Possibly convert docker secrets marked variables.
+source /env_secrets.sh
+
 
 function check {
     "$@"


### PR DESCRIPTION
This brings support for carrying secrets into a bulkstash container when using Docker swarm. Secrets are kept safe all along until `rclone.sh` resolves them to an environment variable in order to pass the information to `rclone`. This is as long as it can go for keeping the information safe while still benefiting from the flexibility of declaring sources and destinations using environment variables. Going further would require the use of a configuration file for `rclone`, a file that would be carried into the container using secrets.

The implementation automatically resolves all environment variables which value is similar to `DOCKER-SECRET::<path>` to the content of the file passed instead of `<path>`. Relative paths are resolved within `/run/secrets`, which is the default location for secrets in swarm. Any other variable which value does not start with `DOCKER-SECRET::` will not be resolved and kept as-is.