### PR TITLE
Add support for specifying architecture when building Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.9
 MAINTAINER Thomas Spicer <thomas@openbridge.com>
 
 ARG RCLONE_VERSION="current"
-ENV RCLONE_TYPE="amd64"
+ARG RCLONE_TYPE="amd64"
 ENV BUILD_DEPS \
       wget \
       linux-headers \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ If you want to build your own image, you need to pass the version you want to us
 docker build --build-arg RCLONE_VERSION=1.47.0 -t openbridge/ob_bulkstash:1.46 .
 docker build --build-arg RCLONE_VERSION=1.47.0 -t openbridge/ob_bulkstash:latest .
 ```
+You may also pass a different architecture: `--build-arg RCLONE_TYPE=arm`
+
 Got your version setup? Great. Next, we need to define a configuration for remote storage locations. The following demonstrates how to sync Amazon and Google cloud storages.
 
 ### Testing Your Build


### PR DESCRIPTION
I found this docker image useful for getting `rclone` running on a Raspberry Pi, but needed to modify the Dockerfile in order to specify arm architecture when building the image.  I was hoping I could upstream the changes as they allow overriding the default but shouldn't interfere with the standard build process.

From [a search](https://github.com/openbridge/ob_bulkstash/search?q=RCLONE_TYPE&unscoped_q=RCLONE_TYPE), RCLONE_TYPE is only ever used in the Dockerfile so changing it to a build arg should be OK.  I updated the README with information about how to use this parameter when building the image.